### PR TITLE
Pico consensus fixes

### DIFF
--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -207,6 +207,9 @@ export class NanoNetworkApi {
                             resolved = true;
                             resolve(new Map(picoBalances)); // create a copy to be able to clear picoBalances map
                             this.__consensusEstablished();
+                            // upgrade to normal nano consensus to enable housekeeping in Network and to reconnect
+                            // automatically in case of lost connection
+                            this.connect();
                         }
                     }
                 }

--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -128,14 +128,18 @@ export class NanoNetworkApi {
             let currentHead = null;
             /** @type {Map<string, number>} */
             const picoBalances = new Map();
+
             let resolved = false;
+            let usingFallback = false;
 
             const fallbackToNanoConsensus = async () => {
-                this.connect()
+                if (resolved || usingFallback) return;
+                usingFallback = true;
+                await this.connect();
                 const balances = await this.getBalance(userFriendlyAddresses);
-                resolve(balances);
                 resolved = true;
-            }
+                resolve(balances);
+            };
 
             const onChannelHead = (channel, header) => {
                 this._picoChannels.push(channel);
@@ -237,7 +241,7 @@ export class NanoNetworkApi {
             }
 
             setTimeout(() => {
-                if (resolved) return;
+                if (resolved || usingFallback) return;
                 fallbackToNanoConsensus();
             }, 5000);
         });

--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -104,7 +104,9 @@ export class NanoNetworkApi {
      * @returns {Promise<Map<string, number>>}
      */
     async connectPico(userFriendlyAddresses = []) {
+        this._shouldConnect = true;
         await this._apiInitialized;
+        if (!this._shouldConnect) return new Map();
 
         const establishedChannels = [];
         const picoHeads = [];

--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -223,15 +223,22 @@ export class NanoNetworkApi {
                     const agent = new Nimiq.NetworkAgent(this._consensus.blockchain, this._consensus.network.addresses,
                         networkConfig, channel);
                     let header = null;
+
+                    // Note that we stop the pico consensus checks once a consensus was reached (either by pico or nano
+                    // fallback). However, during nano fallback, we keep them alive as we might still get to a pico
+                    // consensus before the nano consensus.
                     channel.on('head', (msg) => {
+                        if (resolved) return;
                         header = msg.header;
                         console.debug(`[Pico] Current height is ${header.height}`);
                         onChannelHead(channel, header);
                     });
                     channel.on('accounts-proof', (msg) => {
+                        if (resolved) return;
                         onBalancesMsg(msg);
                     })
                     agent.on('handshake', () => {
+                        if (resolved) return;
                         channel.getHead();
                     });
                 });

--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -439,7 +439,12 @@ export class NanoNetworkApi {
      */
     async _getAccounts(addresses, stackHeight) {
         if (addresses.length === 0) return [];
-        await this._consensusEstablished;
+        // checking for real (nano) consensus here instead of this._consensusEstablished as it doesn't work with pico
+        if (!this._consensus.established) {
+            let listenerId;
+            await new Promise(resolve => listenerId = this._consensus.on('established', resolve));
+            this._consensus.off('established', listenerId);
+        }
         let accounts;
         const addressesAsAddresses = addresses.map(address => Nimiq.Address.fromUserFriendlyAddress(address));
         try {

--- a/src/nano-network-api.js
+++ b/src/nano-network-api.js
@@ -129,6 +129,12 @@ export class NanoNetworkApi {
                 // already nano consensus established
                 const balances = await this.getBalance(userFriendlyAddresses);
                 for (const [address, balance] of balances) { this._balances.set(address, balance); }
+                if (upgradeToNano) {
+                    // Although we established a nano consensus it might be that it was only reached with our selected
+                    // pico peers. Therefore we upgrade to nano again. Note that if we are already on real nano, a
+                    // double invocation of connect doesn't do any harm.
+                    this.connect();
+                }
                 return balances;
             } else {
                 // hook into the current sync process


### PR DESCRIPTION
Many pico consensus fixes, especially to make the `connectPico` method behave consinstent to the normal `connect` method, but also several bug fixes.

- `connectPico` and `connect` can now be called anytime in any order and repeatedly without breaking stuff. Thus, there is no need to call `disconnect` first or to avoid double invocations.
- `connectPico` and `connect` now work on the same consensus instance. No additional volatile instances are created anymore. Pico actually automatically upgrades to nano after initial consensus (if desired). On the other hand, if `connectPico` is called after a nano consensus was started, it hooks the pico logic into the ongoing sync process.
- Methods on the consensus like `getBalance` or `relayTransaction` can now be called when using pico consensus. Before, the pico consensus instance was not exposed but rather abandoned (and not even disconnected). Thus, if one wanted to call consensus methods, an additional nano consensus had to be established alongside pico. Also methods now usually return a result before a normal nano would have been established.
- Make pico consensus fire events like `consensus-established`.
- Make pico consensus reconnect after disconnect (if desired).
- Avoid double invocation of nano fallback and stop executing pico sync handlers after consensus.
- Add checked addresses to `this._balances` as is done in `getBalance`.
- Reject `connectPico` if fallback fails.
- Don't report head changes multiple times for same head
- Add similar `_shouldConnect` guard as in `connect` and `disconnect`
- Support reaching pico consensus also if no accounts have been requested

See the commit messages for additional descriptions.

This has been tested, but not super exhaustively yet.